### PR TITLE
Fix 'charmap' codec can't decode byte 0x81 in position 317

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -61,7 +61,7 @@ class MainWindow(QMainWindow):
 
     def __langChanged(self, lang=None):
         translations = {}
-        with open('translations.json', 'r') as file:
+        with open('translations.json', 'r', encoding='utf-8') as file:
             translations = json.load(file)
 
         language = lang


### PR DESCRIPTION
UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 317: character maps to <undefined>

changing the language crashed the program, with this i fixed it ( Windows 10, LTSC 21H2)